### PR TITLE
Require setuptools less than 70.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 zc.buildout == 3.0.1
+setuptools < 70


### PR DESCRIPTION
Otherwise `make all` fails.  Tried with both Python 3.8 and 3.11.

```
$ make all
python3 -m venv .venv
./.venv/bin/pip install -IUr requirements.txt
Collecting zc.buildout==3.0.1 (from -r requirements.txt (line 1))
  Using cached zc.buildout-3.0.1-py2.py3-none-any.whl.metadata (24 kB)
Collecting setuptools>=8.0 (from zc.buildout==3.0.1->-r requirements.txt (line 1))
  Downloading setuptools-70.0.0-py3-none-any.whl.metadata (5.9 kB)
Collecting pip (from zc.buildout==3.0.1->-r requirements.txt (line 1))
  Using cached pip-24.0-py3-none-any.whl.metadata (3.6 kB)
Collecting wheel (from zc.buildout==3.0.1->-r requirements.txt (line 1))
  Using cached wheel-0.43.0-py3-none-any.whl.metadata (2.2 kB)
Using cached zc.buildout-3.0.1-py2.py3-none-any.whl (168 kB)
Downloading setuptools-70.0.0-py3-none-any.whl (863 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 863.4/863.4 kB 6.8 MB/s eta 0:00:00
Using cached pip-24.0-py3-none-any.whl (2.1 MB)
Using cached wheel-0.43.0-py3-none-any.whl (65 kB)
Installing collected packages: wheel, setuptools, pip, zc.buildout
Successfully installed pip-24.0 setuptools-65.5.0 wheel-0.43.0 zc.buildout-3.0.1
./.venv/bin/buildout
Traceback (most recent call last):
  File "/Users/maurits/syslab/quoira/nginx/./.venv/bin/buildout", line 5, in <module>
    from zc.buildout.buildout import main
  File "/Users/maurits/syslab/quoira/nginx/.venv/lib/python3.11/site-packages/zc/buildout/buildout.py", line 18, in <module>
    import zc.buildout.easy_install
  File "/Users/maurits/syslab/quoira/nginx/.venv/lib/python3.11/site-packages/zc/buildout/easy_install.py", line 28, in <module>
    from pkg_resources import packaging
ImportError: cannot import name 'packaging' from 'pkg_resources' (/Users/maurits/syslab/quoira/nginx/.venv/lib/python3.11/site-packages/pkg_resources/__init__.py)
make: *** [.installed.cfg] Error 1
```

I don't know the reason.  I see no direct cause in https://setuptools.pypa.io/en/latest/history.html#v70-0-0